### PR TITLE
회원 API - 소셜 로그인 API를 통한 로그인 기능 및 JWT 토큰 발급

### DIFF
--- a/src/main/java/com/project/bookstudy/common/dto/Error.java
+++ b/src/main/java/com/project/bookstudy/common/dto/Error.java
@@ -2,10 +2,12 @@ package com.project.bookstudy.common.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
-@AllArgsConstructor
-public enum ErrorCode {
+@RequiredArgsConstructor
+public enum Error {
     USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
     EMAIL_ALREADY_EXISTS("이메일이 이미 존재합니다."),
     VALIDATION_ERROR("유효성 검사 에러"),

--- a/src/main/java/com/project/bookstudy/common/dto/ErrorResponse.java
+++ b/src/main/java/com/project/bookstudy/common/dto/ErrorResponse.java
@@ -10,12 +10,12 @@ import java.util.Map;
 public class ErrorResponse {
 
     private String code;
-    private String message;
+    private String description;
     private Map<String, List<String>> errorDetails; // 유효성 검사 여러개 발견될 경우 사용
     @Builder
     private ErrorResponse(String code, String message) {
         this.code = code;
-        this.message = message;
+        this.description = message;
     }
 
 }

--- a/src/main/java/com/project/bookstudy/common/exception/AuthException.java
+++ b/src/main/java/com/project/bookstudy/common/exception/AuthException.java
@@ -1,0 +1,17 @@
+package com.project.bookstudy.common.exception;
+
+import com.project.bookstudy.common.dto.Error;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+
+    private final Error error;
+    private final String description;
+
+    public AuthException(Error error) {
+        this.error = error;
+        this.description = error.getDescription();
+    }
+
+}

--- a/src/main/java/com/project/bookstudy/common/exception/MemberException.java
+++ b/src/main/java/com/project/bookstudy/common/exception/MemberException.java
@@ -1,0 +1,19 @@
+package com.project.bookstudy.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class MemberException extends RuntimeException {
+
+    private final Error error;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public MemberException(Error error) {
+        this.error = error;
+        this.message = error.getMessage();
+        this.httpStatus = error.getHttpStatus();
+    }
+
+}

--- a/src/main/java/com/project/bookstudy/common/exception/MemberException.java
+++ b/src/main/java/com/project/bookstudy/common/exception/MemberException.java
@@ -1,19 +1,17 @@
 package com.project.bookstudy.common.exception;
 
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
+import com.project.bookstudy.common.dto.Error;
 
 @Getter
 public class MemberException extends RuntimeException {
 
     private final Error error;
     private final String message;
-    private final HttpStatus httpStatus;
 
     public MemberException(Error error) {
         this.error = error;
-        this.message = error.getMessage();
-        this.httpStatus = error.getHttpStatus();
+        this.message = error.getDescription();
     }
 
 }

--- a/src/main/java/com/project/bookstudy/member/domain/Member.java
+++ b/src/main/java/com/project/bookstudy/member/domain/Member.java
@@ -46,4 +46,8 @@ public class Member {
         this.name = name;
     }
 
+    public void updateRefreshToken(String updateRefreshToken) {
+        this.refreshToken = updateRefreshToken;
+    }
+
 }

--- a/src/main/java/com/project/bookstudy/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/bookstudy/member/repository/MemberRepository.java
@@ -7,5 +7,10 @@ import java.util.Optional;
 
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    // email을 통해 회원 찾기
     Optional<Member> findByEmail(String email);
+
+    // RefreshToken 정보 찾기
+    Optional<Member> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/project/bookstudy/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/bookstudy/security/config/SecurityConfig.java
@@ -35,8 +35,7 @@ public class SecurityConfig {
                 .mvcMatchers("/test").authenticated()
                 .anyRequest().permitAll();
 
-        http
-                .oauth2Login()
+        http.oauth2Login()
                 .userInfoEndpoint().userService(kakaoOAuth2MemberService)
                 .and()
                 .successHandler(oAuth2LoginSuccessHandler)

--- a/src/main/java/com/project/bookstudy/security/config/SecurityOAuthConfig.java
+++ b/src/main/java/com/project/bookstudy/security/config/SecurityOAuthConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 public class SecurityOAuthConfig {
 

--- a/src/main/java/com/project/bookstudy/security/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/project/bookstudy/security/filter/JwtAuthenticationProcessingFilter.java
@@ -1,5 +1,7 @@
 package com.project.bookstudy.security.filter;
 
+import com.project.bookstudy.common.dto.Error;
+import com.project.bookstudy.common.exception.AuthException;
 import com.project.bookstudy.member.domain.Member;
 import com.project.bookstudy.member.repository.MemberRepository;
 import com.project.bookstudy.security.service.JwtTokenService;
@@ -20,6 +22,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * [Jwt 인증 필터]
@@ -100,13 +103,13 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     public void setAuthentication(Member member) {
         String password = member.getPassword();
         if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 인증 되도록 설정
-            password = RandomStringMaker.randomStringMaker();
+            password = UUID.randomUUID().toString();
         }
 
         UserDetails userDetailsUser = User.builder()
                 .username(member.getEmail())
                 .password(password)
-                .roles(member.getMemberRole().name())
+                .roles(member.getRole().name())
                 .build();
 
         Authentication authentication =

--- a/src/main/java/com/project/bookstudy/security/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/project/bookstudy/security/filter/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,118 @@
+package com.project.bookstudy.security.filter;
+
+import com.project.bookstudy.member.domain.Member;
+import com.project.bookstudy.member.repository.MemberRepository;
+import com.project.bookstudy.security.service.JwtTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * [Jwt 인증 필터]
+ *
+ * 기본적으로 사용자는 요청 헤더에 AccessToken만 담아서 요청
+ * AccessToken 만료 시에만 RefreshToken을 요청 헤더에 담아서 요청
+ *
+ * 1. RefreshToken이 헤더에 없고, AccessToken이 유효한 경우 -> 인증 성공 처리, RefreshToken을 재발급하지는 않는다.
+ * 2. RefreshToken이 헤더에 없고, AccessToken이 없거나 유효하지 않은 경우 -> 인증 실패 처리 (토큰 관련 예외는 ExceptionHandlerFilter에서 처리)
+ * 3. RefreshToken이 헤더에 있는 경우 -> DB의 RefreshToken과 비교하여 일치하면 AccessToken, RefreshToken 재발급(RTR 방식)
+ * 인증 성공 처리는 하지 않고 실패 처리
+ */
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+
+
+    private final JwtTokenService jwtTokenService;
+    private final MemberRepository memberRepository;
+
+    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String refreshToken = jwtTokenService.extractRefreshToken(request)
+                .filter(jwtTokenService::isTokenValid)
+                .orElse(null);
+
+        if (refreshToken != null) {
+            checkRefreshTokenAndReIssueAccessAndRefreshToken(response, refreshToken);
+            return; // RefreshToken을 보낸 경우에는 AccessToken & RefreshToken을 재발급 해주는 메서드 호출, 인증 처리는 하지 않게 하기위해 바로 return으로 필터 진행 막기
+        }
+
+        checkAccessTokenAndAuthentication(request);
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * [RefreshToken 토큰으로 유저 정보 찾기 & 액세스 토큰/리프레시 토큰 재발급]
+     */
+    public void checkRefreshTokenAndReIssueAccessAndRefreshToken(HttpServletResponse response, String refreshToken) {
+        Member member = memberRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new AuthException(Error.TOKEN_INVALID));
+
+        String reIssuedRefreshToken = reIssueRefreshToken(member);
+        jwtTokenService.sendAccessAndRefreshToken(response, jwtTokenService.createAccessToken(member.getId()),
+                reIssuedRefreshToken);
+
+    }
+
+    /**
+     * [RefreshToken 토큰 재발급 & DB에 업데이트]
+     */
+    private String reIssueRefreshToken(Member member) {
+        String reIssuedRefreshToken = jwtTokenService.createRefreshToken();
+        member.updateRefreshToken(reIssuedRefreshToken);
+        memberRepository.saveAndFlush(member);
+        return reIssuedRefreshToken;
+    }
+
+    /**
+     * [액세스 토큰 체크 & 인증 처리]
+     */
+    public void checkAccessTokenAndAuthentication(HttpServletRequest request) throws ServletException, IOException {
+        log.info("checkAccessTokenAndAuthentication() 호출");
+        jwtTokenService.extractAccessToken(request)
+                .filter(jwtTokenService::isTokenValid)
+                .ifPresent(accessToken -> jwtTokenService.extractId(accessToken)
+                        .ifPresent(id -> memberRepository.findById(id)
+                                .ifPresent(this::setAuthentication)));
+    }
+
+    /**
+     * [인증 허가]
+     */
+    public void setAuthentication(Member member) {
+        String password = member.getPassword();
+        if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 인증 되도록 설정
+            password = RandomStringMaker.randomStringMaker();
+        }
+
+        UserDetails userDetailsUser = User.builder()
+                .username(member.getEmail())
+                .password(password)
+                .roles(member.getMemberRole().name())
+                .build();
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+                        authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/project/bookstudy/security/filter/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/project/bookstudy/security/filter/handler/OAuth2LoginFailureHandler.java
@@ -1,6 +1,6 @@
 package com.project.bookstudy.security.filter.handler;
 
-import com.project.bookstudy.common.dto.ErrorCode;
+import com.project.bookstudy.common.dto.Error;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -20,7 +20,7 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
         response.setContentType("application/json");
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        response.getWriter().write(String.valueOf(ErrorCode.LOGIN_FAILED));
+        response.getWriter().write(String.valueOf(Error.LOGIN_FAILED));
 
         log.info("로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
     }

--- a/src/main/java/com/project/bookstudy/security/filter/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/bookstudy/security/filter/handler/OAuth2LoginSuccessHandler.java
@@ -1,5 +1,7 @@
 package com.project.bookstudy.security.filter.handler;
 
+import com.project.bookstudy.common.dto.Error;
+import com.project.bookstudy.common.exception.MemberException;
 import com.project.bookstudy.member.domain.Member;
 import com.project.bookstudy.member.repository.MemberRepository;
 import com.project.bookstudy.security.service.JwtTokenService;

--- a/src/main/java/com/project/bookstudy/security/service/JwtTokenService.java
+++ b/src/main/java/com/project/bookstudy/security/service/JwtTokenService.java
@@ -1,0 +1,167 @@
+package com.project.bookstudy.security.service;
+
+import com.project.bookstudy.member.domain.Member;
+import com.project.bookstudy.member.repository.MemberRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.security.Key;
+import java.util.Date;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Getter
+public class JwtTokenService {
+
+    private Key key;
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    private final MemberRepository memberRepository;
+
+    public JwtTokenService(@Value("${jwt.secret}") String secretKey, MemberRepository memberRepository) {
+        byte[] bytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(bytes);
+
+        this.memberRepository = memberRepository;
+    }
+
+    public static final String MEMBER_ID = "memberId";
+
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;    // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14; // 14일
+
+
+    /**
+     * Access 토큰 생성
+     */
+    public String createAccessToken(Long memberId) {
+        Claims claims = Jwts.claims();
+        claims.put(MEMBER_ID, memberId);
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Refresh 토큰 생성
+     */
+    public String createRefreshToken() {
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+    }
+
+    /**
+     * AccessToken + RefreshToken 헤더에 실어서 전송
+     */
+    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        setAccessTokenHeader(response, accessToken);
+        setRefreshTokenHeader(response, refreshToken);
+
+        log.info("access 토큰 : " + accessToken);
+        log.info("refresh 토큰 : " + refreshToken);
+    }
+
+    /**
+     * 헤더에서 AccessToken 추출
+     * 토큰 형식 : Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
+     * 헤더를 가져온 후 "Bearer"를 삭제(""로 replace)
+     */
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(accessToken -> accessToken.startsWith("Bearer "))
+                .map(accessToken -> accessToken.replace("Bearer ", ""));
+    }
+
+    /**
+     * 헤더에서 RefreshToken 추출
+     * 토큰 형식 : Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
+     * 헤더를 가져온 후 "Bearer"를 삭제하기(""로 replace 진행)
+     */
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(refreshHeader))
+                .filter(refreshToken -> refreshToken.startsWith("Bearer "))
+                .map(refreshToken -> refreshToken.replace("Bearer ", ""));
+    }
+
+    /**
+     * AccessToken에서 Id 추출
+     */
+    public Optional<Long> extractId(String accessToken) {
+        Jws<Claims> claimsJws = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken);
+
+        // Email 클레임 추출
+        Long idClaim = claimsJws.getBody().get(MEMBER_ID, Long.class);
+        return Optional.ofNullable(idClaim);
+    }
+
+    /**
+     * AccessToken 헤더 설정
+     */
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(accessHeader, accessToken);
+    }
+
+    /**
+     * RefreshToken 헤더 설정
+     */
+    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+        response.setHeader(refreshHeader, refreshToken);
+    }
+
+    /**
+     * RefreshToken DB 저장(업데이트)
+     */
+    @Transactional
+    public void updateRefreshToken(String email, String refreshToken) {
+        Optional<Member> memberOptional = memberRepository.findByEmail(email);
+        Member member = memberOptional.get();
+        member.updateRefreshToken(refreshToken);
+    }
+
+    /**
+     * Token 유효성 검사
+     */
+    public boolean isTokenValid(String token) {
+        Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+        return true;
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,3 +64,9 @@ logging:
 
 jwt:
   secret: ${JWT_SECRET}
+
+  access:
+    header: Authorization
+
+  refresh:
+    header: Authorization-refresh


### PR DESCRIPTION
##  Feature


- 카카오 로그인 성공 이후 JWT 토큰 발급되도록 구현했습니다.

- RefreshToken은 회원 DB에 저장했습니다.

## Test

- [x] API 테스트

- 로그인 성공
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/78e9f0fc-a1c9-4155-8cea-4b566b720daf)

- JWT 토큰 발급 
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/e984b33a-8204-4881-954a-030af3bb12b4)



