### PR TITLE
스터디그룹 API - DELETE 기능

### DIFF
--- a/src/main/java/com/project/bookstudy/study_group/controller/StudyGroupController.java
+++ b/src/main/java/com/project/bookstudy/study_group/controller/StudyGroupController.java
@@ -82,7 +82,7 @@ public class StudyGroupController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteStudyGroup(@PathVariable("id") Long studyGroupId
             , Authentication authentication) {
-        studyGroupService.cancelStudyGroup(studyGroupId, authentication);
+        studyGroupService.deleteStudyGroup(studyGroupId, authentication);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/project/bookstudy/study_group/controller/StudyGroupController.java
+++ b/src/main/java/com/project/bookstudy/study_group/controller/StudyGroupController.java
@@ -79,6 +79,12 @@ public class StudyGroupController {
         return ResponseEntity.ok().build();
     }
 
+    /**
+     *
+     * @param studyGroupId
+     * @param authentication
+     * 스터디그룹 삭제 (소프트 삭제)
+     */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteStudyGroup(@PathVariable("id") Long studyGroupId
             , Authentication authentication) {

--- a/src/main/java/com/project/bookstudy/study_group/controller/StudyGroupController.java
+++ b/src/main/java/com/project/bookstudy/study_group/controller/StudyGroupController.java
@@ -79,4 +79,11 @@ public class StudyGroupController {
         return ResponseEntity.ok().build();
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteStudyGroup(@PathVariable("id") Long studyGroupId
+            , Authentication authentication) {
+        studyGroupService.cancelStudyGroup(studyGroupId, authentication);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/project/bookstudy/study_group/domain/StudyGroup.java
+++ b/src/main/java/com/project/bookstudy/study_group/domain/StudyGroup.java
@@ -1,5 +1,6 @@
 package com.project.bookstudy.study_group.domain;
 
+import com.project.bookstudy.common.dto.ErrorCode;
 import com.project.bookstudy.member.domain.Member;
 import com.project.bookstudy.study_group.domain.param.CreateStudyGroupParam;
 import com.project.bookstudy.study_group.domain.param.UpdateStudyGroupParam;
@@ -84,6 +85,25 @@ public class StudyGroup {
         this.studyEndDt = param.getStudyEndDt();
         this.recruitmentStartDt = param.getRecruitmentStartDt();
         this.recruitmentEndDt = param.getRecruitmentEndDt();
+    }
+
+    public boolean isStarted() {
+        if (LocalDateTime.now().isAfter(studyStartDt)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 스터디 시작 날짜 이후에는 cancel 불가
+     */
+    public void cancel() {
+
+        if (isStarted()) {
+            throw new IllegalStateException(ErrorCode.STUDY_GROUP_CANCEL_FAIL.getDescription());
+        }
+
+        status = StudyGroupStatus.RECRUIT_CANCEL;
     }
 
 }

--- a/src/main/java/com/project/bookstudy/study_group/service/StudyGroupService.java
+++ b/src/main/java/com/project/bookstudy/study_group/service/StudyGroupService.java
@@ -67,4 +67,24 @@ public class StudyGroupService {
 
         studyGroup.update(updateParam);
     }
+
+    @Transactional
+    public void deleteStudyGroup(Long studyGroupId, Authentication authentication) {
+
+        StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getDescription()));
+
+        Member member = memberRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new MemberException(ErrorCode.USER_NOT_FOUND));
+
+        if (studyGroup.getLeader().getId() != member.getId()) {
+            throw new IllegalArgumentException(ErrorCode.STUDY_GROUP_UPDATE_FAIL.getDescription());
+        }
+
+        if (studyGroup.isStarted()) {
+            throw new IllegalStateException(ErrorCode.STUDY_GROUP_CANCEL_FAIL.getDescription());
+        }
+
+        studyGroup.cancel();
+    }
 }

--- a/src/test/java/com/project/bookstudy/study_group/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/project/bookstudy/study_group/service/StudyGroupServiceTest.java
@@ -325,7 +325,7 @@ class StudyGroupServiceTest {
 
     }
 
-    @DisplayName("스터디 그룹 삭제 (= 모집 취소)")
+    @DisplayName("스터디 그룹 삭제 성공 (= 모집 취소)")
     @Test
     @Transactional
     void cancelSuccess() {
@@ -348,6 +348,32 @@ class StudyGroupServiceTest {
 
         //then
         assertThat(studyGroup.getStatus()).isEqualTo(StudyGroupStatus.RECRUIT_CANCEL);
+    }
+
+    @DisplayName("스터디 그룹 삭제 실패 - 스터디가 시작된 경우 삭제 불가 (현재 날짜 > 스터디 시작 날짜)")
+    @Test
+    @Transactional
+    void cancelFailed() {
+        //given
+
+        Member member1 = createMember("스터디 리더", "dlaehdgus23@naver.com");
+        memberRepository.save(member1);
+        Authentication authentication = createAuthentication();
+
+        CreateStudyGroupRequest request = createStudyCreateGroupRequest(member1.getId(),
+                LocalDateTime.of(2023, 11, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 2, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 30, 0, 0, 0), "subject", "contents");
+        StudyGroup studyGroup = request.toCreateServiceParam().toEntityWithLeader(member1);
+        studyGroupRepository.save(studyGroup);
+
+        //when
+        if (!studyGroup.isStarted()) {
+            studyGroupService.deleteStudyGroup(studyGroup.getId(), authentication);
+        }
+        //then
+        assertThat(studyGroup.getStatus()).isNotEqualTo(StudyGroupStatus.RECRUIT_CANCEL);
     }
 
     /**

--- a/src/test/java/com/project/bookstudy/study_group/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/project/bookstudy/study_group/service/StudyGroupServiceTest.java
@@ -5,6 +5,7 @@ import com.project.bookstudy.common.exception.MemberException;
 import com.project.bookstudy.member.domain.Member;
 import com.project.bookstudy.member.repository.MemberRepository;
 import com.project.bookstudy.study_group.domain.StudyGroup;
+import com.project.bookstudy.study_group.domain.StudyGroupStatus;
 import com.project.bookstudy.study_group.dto.StudyGroupDto;
 import com.project.bookstudy.study_group.dto.request.CreateStudyGroupRequest;
 import com.project.bookstudy.study_group.dto.request.UpdateStudyGroupRequest;
@@ -324,6 +325,30 @@ class StudyGroupServiceTest {
 
     }
 
+    @DisplayName("스터디 그룹 삭제 (= 모집 취소)")
+    @Test
+    @Transactional
+    void cancelSuccess() {
+        //given
+
+        Member member1 = createMember("스터디 리더", "dlaehdgus23@naver.com");
+        memberRepository.save(member1);
+        Authentication authentication = createAuthentication();
+
+        CreateStudyGroupRequest request = createStudyCreateGroupRequest(member1.getId(),
+                LocalDateTime.of(2023, 12, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 12, 2, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 30, 0, 0, 0), "subject", "contents");
+        StudyGroup studyGroup = request.toCreateServiceParam().toEntityWithLeader(member1);
+        studyGroupRepository.save(studyGroup);
+
+        //when
+        studyGroupService.deleteStudyGroup(studyGroup.getId(), authentication);
+
+        //then
+        assertThat(studyGroup.getStatus()).isEqualTo(StudyGroupStatus.RECRUIT_CANCEL);
+    }
 
     /**
      *


### PR DESCRIPTION
##  Feature


- 스터디그룹 삭제 기능 구현했습니다.
- 스터디그룹 삭제 시, 컬럼 삭제가 아닌 삭제(=모집 취소) 상태로 구분하도록 진행했습니다.

## Test

- [x] API 테스트
- [x] 테스트 코드



- API 테스트
1. 스터디그룹 삭제 전
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/21e573df-4a43-4693-b967-9d72aaf9cbf4)

2. 스터디그룹 삭제 후
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/aae12831-9fcb-43f8-bed9-cc8cab6f8b81)

- 테스트 코드
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/3336c1c3-e083-4ba2-aa0f-fc563937797b)
