### PR TITLE
신청 API - 신청, 조회, 취소

### DIFF
--- a/src/main/java/com/project/bookstudy/common/aop/DistributedLock.java
+++ b/src/main/java/com/project/bookstudy/common/aop/DistributedLock.java
@@ -1,0 +1,35 @@
+package com.project.bookstudy.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface DistributedLock {
+
+    /**
+     * 락의 이름
+     */
+    String key() default "";
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+
+}

--- a/src/main/java/com/project/bookstudy/common/aop/DistributedLockAop.java
+++ b/src/main/java/com/project/bookstudy/common/aop/DistributedLockAop.java
@@ -1,0 +1,80 @@
+package com.project.bookstudy.common.aop;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+/**
+ * @DistributedLock 선언 시 수행되는 Aop class
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Order(1)  // Lock 획득 > transaction 시작 > Service 로직 > transaction 종료 > Lock 반납
+@Slf4j
+public class DistributedLockAop {
+
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(com.project.bookstudy.common.aop.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+
+        Method method = signature.getMethod();
+
+
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+
+        String keyExpression = distributedLock.key();
+        String key = evaluateSpEL(keyExpression, joinPoint);
+
+        RLock rLock = redissonClient.getLock(REDISSON_LOCK_PREFIX + key);
+
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!available) {
+                return false;
+            }
+            return joinPoint.proceed();
+
+        } catch (InterruptedException e) {
+            log.error("InterruptedException occurred while acquiring the lock: " + e.getMessage());
+            return null;
+        } finally {
+            try {
+                rLock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson Lock Already UnLock");
+            }
+        }
+    }
+    private String evaluateSpEL(String expression, ProceedingJoinPoint joinPoint) {
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        Object[] args = joinPoint.getArgs();
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] parameterNames = signature.getParameterNames();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        ExpressionParser parser = new SpelExpressionParser();
+        return parser.parseExpression(expression).getValue(context, String.class);
+    }
+}

--- a/src/main/java/com/project/bookstudy/common/dto/ErrorCode.java
+++ b/src/main/java/com/project/bookstudy/common/dto/ErrorCode.java
@@ -32,7 +32,7 @@ public enum ErrorCode {
     DUPLICATE_ENROLLMENT_ERROR("해당 스터디 그룹에 이미 신청한 상태입니다."),
     ENROLLMENT_NOT_FOUND("해당 신청 정보가 없습니다."),
     RECRUITMENT_DATE_END("모집 기간이 아닙니다."),
-    ENROLLMENT_CANCEL_FAIL("해당 스터디가 진행되면 신청 취소가 불가합니다."),
+    ENROLLMENT_CANCEL_FAIL("해당 스터디가 진행되면 신청 취소 실패했습니다."),
     STUDY_GROUP_UPDATE_FAIL("스터디그룹을 생성한 사람만 수정할 수 있습니다."),
     REFUND_FAIL("환불 실패");
 

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -21,8 +21,9 @@ public class EnrollmentController {
      * @param authentication
      * 스터디 그룹 신청하기
      */
-    @PostMapping
-    public ResponseEntity<CreateEnrollmentResponse> createEnrollment(@RequestParam Long StudyGroupId, Authentication authentication) {
-        return ResponseEntity.ok(enrollmentService.enroll(StudyGroupId, authentication));
+    @PostMapping("/{studyGroupId}")
+    public ResponseEntity<Void> createEnrollment(@PathVariable Long studyGroupId, Authentication authentication) {
+        enrollmentService.enroll(studyGroupId,authentication);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -25,4 +25,14 @@ public class EnrollmentController {
     public ResponseEntity<Long> createEnrollment(@PathVariable Long studyGroupId, Authentication authentication) {
         return ResponseEntity.ok(enrollmentService.enroll(studyGroupId,authentication));
     }
+
+    /**
+     * @param enrollmentId
+     * 스터디 그룹 취소하기
+     */
+    @DeleteMapping("/{enrollmentId}")
+    public ResponseEntity<Void> cancelEnrollment(@PathVariable("enrollmentId") Long enrollmentId, Authentication authentication) {
+        enrollmentService.cancel(enrollmentId, authentication);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -1,6 +1,7 @@
 package com.project.bookstudy.enrollment.controller;
 
 import com.project.bookstudy.enrollment.dto.CreateEnrollmentResponse;
+import com.project.bookstudy.enrollment.service.EnrollmentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -1,5 +1,6 @@
 package com.project.bookstudy.enrollment.controller;
 
+import com.project.bookstudy.enrollment.dto.CreateEnrollmentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -1,0 +1,26 @@
+package com.project.bookstudy.enrollment.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/enrollment")
+public class EnrollmentController {
+
+    private final EnrollmentService enrollmentService;
+
+
+    /**
+     *
+     * @param StudyGroupId
+     * @param authentication
+     * 스터디 그룹 신청하기
+     */
+    @PostMapping
+    public ResponseEntity<CreateEnrollmentResponse> createEnrollment(@RequestParam Long StudyGroupId, Authentication authentication) {
+        return ResponseEntity.ok(enrollmentService.enroll(StudyGroupId, authentication));
+    }
+}

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -60,7 +60,7 @@ public class EnrollmentController {
     @GetMapping
     public ResponseEntity<Page<EnrollmentDto>> getEnrollmentList(@PageableDefault Pageable pageable,
                                                  @ModelAttribute EnrollmentSearchCond cond) {
-        //응답 정보 선별 하고싶으면, Dto에서 정보 선별 및 응답 객체 생성
-        return ResponseEntity.ok(enrollmentService.getEnrollmentList(pageable, cond.getMemberId()));
+        Page<EnrollmentDto> enrollmentList = enrollmentService.getEnrollmentList(pageable, cond.getMemberId());
+        return ResponseEntity.ok(enrollmentList);
     }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -4,6 +4,9 @@ import com.project.bookstudy.enrollment.dto.CreateEnrollmentResponse;
 import com.project.bookstudy.enrollment.service.EnrollmentService;
 import com.project.bookstudy.study_group.dto.EnrollmentDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -45,5 +48,18 @@ public class EnrollmentController {
     @GetMapping("/{id}")
     public ResponseEntity<EnrollmentDto> getEnrollment(@PathVariable("id") Long enrollmentId) {
         return ResponseEntity.ok(enrollmentService.getEnrollment(enrollmentId));
+    }
+
+    /**
+     *
+     * @param pageable
+     * @param cond
+     * 스터디 그룹 신청내역 전체조회
+     */
+    @GetMapping
+    public Page<EnrollmentDto> getEnrollmentList(@PageableDefault Pageable pageable,
+                                                 @ModelAttribute EnrollmentSearchCond cond) {
+        //응답 정보 선별 하고싶으면, Dto에서 정보 선별 및 응답 객체 생성
+        return enrollmentService.getEnrollmentList(pageable, cond.getMemberId());
     }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -3,6 +3,7 @@ package com.project.bookstudy.enrollment.controller;
 import com.project.bookstudy.enrollment.dto.CreateEnrollmentResponse;
 import com.project.bookstudy.enrollment.service.EnrollmentService;
 import com.project.bookstudy.study_group.dto.EnrollmentDto;
+import com.project.bookstudy.study_group.dto.request.EnrollmentSearchCond;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -17,7 +17,7 @@ public class EnrollmentController {
 
     /**
      *
-     * @param StudyGroupId
+     * @param studyGroupId
      * @param authentication
      * 스터디 그룹 신청하기
      */

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -58,9 +58,9 @@ public class EnrollmentController {
      * 스터디 그룹 신청내역 전체조회
      */
     @GetMapping
-    public Page<EnrollmentDto> getEnrollmentList(@PageableDefault Pageable pageable,
+    public ResponseEntity<Page<EnrollmentDto>> getEnrollmentList(@PageableDefault Pageable pageable,
                                                  @ModelAttribute EnrollmentSearchCond cond) {
         //응답 정보 선별 하고싶으면, Dto에서 정보 선별 및 응답 객체 생성
-        return enrollmentService.getEnrollmentList(pageable, cond.getMemberId());
+        return ResponseEntity.ok(enrollmentService.getEnrollmentList(pageable, cond.getMemberId()));
     }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -35,4 +35,14 @@ public class EnrollmentController {
         enrollmentService.cancel(enrollmentId, authentication);
         return ResponseEntity.ok().build();
     }
+
+    /**
+     *
+     * @param enrollmentId
+     * 스터디 그룹 신청내역 단일조회
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<EnrollmentDto> getEnrollment(@PathVariable("id") Long enrollmentId) {
+        return ResponseEntity.ok(enrollmentService.getEnrollment(enrollmentId));
+    }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -22,8 +22,7 @@ public class EnrollmentController {
      * 스터디 그룹 신청하기
      */
     @PostMapping("/{studyGroupId}")
-    public ResponseEntity<Void> createEnrollment(@PathVariable Long studyGroupId, Authentication authentication) {
-        enrollmentService.enroll(studyGroupId,authentication);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Long> createEnrollment(@PathVariable Long studyGroupId, Authentication authentication) {
+        return ResponseEntity.ok(enrollmentService.enroll(studyGroupId,authentication));
     }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/project/bookstudy/enrollment/controller/EnrollmentController.java
@@ -2,6 +2,7 @@ package com.project.bookstudy.enrollment.controller;
 
 import com.project.bookstudy.enrollment.dto.CreateEnrollmentResponse;
 import com.project.bookstudy.enrollment.service.EnrollmentService;
+import com.project.bookstudy.study_group.dto.EnrollmentDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
@@ -3,6 +3,7 @@ package com.project.bookstudy.enrollment.domain;
 import com.project.bookstudy.member.domain.Member;
 import com.project.bookstudy.study_group.domain.StudyGroup;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,5 +33,30 @@ public class Enrollment {
     @JoinColumn(name = "payment_id")
     private Payment payment;
 
+    @Builder(access = AccessLevel.PRIVATE)
+    public Enrollment(Member member, StudyGroup studyGroup, Payment payment) {
 
+        this.enrollmentStatus = EnrollmentStatus.RESERVED;
+        this.member = member;
+        this.studyGroup = studyGroup;
+        this.payment = payment;
+    }
+
+    public static Enrollment createEnrollment(Member member, StudyGroup studyGroup) {
+        // Study Group 인원 체크해야 함
+        // 동시성 문제도 고려해야 함
+        Payment payment = Payment.createPayment(studyGroup, member);
+
+        Enrollment enrollment = Enrollment.builder()
+                .member(member)
+                .studyGroup(studyGroup)
+                .payment(payment)
+                .build();
+
+        //양방향 연관관계 설정
+        studyGroup.getEnrollments().add(enrollment);
+
+        return enrollment;
+
+    }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
@@ -59,4 +59,12 @@ public class Enrollment {
         return enrollment;
 
     }
+
+    public void cancel() {
+        if (status == EnrollmentStatus.CANCEL) return;
+
+        Long refundPrice = payment.refund();
+        member.chargePoint(refundPrice);
+        status = EnrollmentStatus.CANCEL;
+    }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
@@ -31,4 +31,6 @@ public class Enrollment {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "payment_id")
     private Payment payment;
+
+
 }

--- a/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
@@ -1,0 +1,34 @@
+package com.project.bookstudy.enrollment.domain;
+
+import com.project.bookstudy.member.domain.Member;
+import com.project.bookstudy.study_group.domain.StudyGroup;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Enrollment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "enrollment_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private EnrollmentStatus enrollmentStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_group_id")
+    private StudyGroup studyGroup;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "payment_id")
+    private Payment payment;
+}

--- a/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/Enrollment.java
@@ -19,7 +19,7 @@ public class Enrollment {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    private EnrollmentStatus enrollmentStatus;
+    private EnrollmentStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -36,7 +36,7 @@ public class Enrollment {
     @Builder(access = AccessLevel.PRIVATE)
     public Enrollment(Member member, StudyGroup studyGroup, Payment payment) {
 
-        this.enrollmentStatus = EnrollmentStatus.RESERVED;
+        this.status = EnrollmentStatus.RESERVED;
         this.member = member;
         this.studyGroup = studyGroup;
         this.payment = payment;

--- a/src/main/java/com/project/bookstudy/enrollment/domain/EnrollmentStatus.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/EnrollmentStatus.java
@@ -1,0 +1,5 @@
+package com.project.bookstudy.enrollment.domain;
+
+public enum EnrollmentStatus {
+    RESERVED, CANCEL
+}

--- a/src/main/java/com/project/bookstudy/enrollment/domain/Payment.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/Payment.java
@@ -1,7 +1,9 @@
 package com.project.bookstudy.enrollment.domain;
 
 import com.project.bookstudy.member.domain.Member;
+import com.project.bookstudy.study_group.domain.StudyGroup;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,4 +30,31 @@ public class Payment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Payment(Long price, Long discountPrice, Long paymentPrice, Member member) {
+        this.price = price;
+        this.discountPrice = discountPrice;
+        this.paymentPrice = paymentPrice;
+        this.member = member;
+
+        this.paymentDt = LocalDateTime.now();
+        this.status = PaymentStatus.SUCCESS;
+    }
+
+    public static Payment createPayment(StudyGroup studyGroup, Member member) throws IllegalStateException{
+
+        //나중에 할인 정책도입시 할인 금액 계산 로직 작성
+
+        Long price = studyGroup.getPrice();
+        member.usePoint(price); // IllegalStateException
+
+        Payment payment = Payment.builder()
+                .member(member)
+                .price(price)
+                .discountPrice(price)
+                .paymentPrice(price)
+                .build();
+        return payment;
+    }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/domain/Payment.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/Payment.java
@@ -57,4 +57,11 @@ public class Payment {
                 .build();
         return payment;
     }
+
+    public Long refund() {
+        if (status == PaymentStatus.REFUNDED) return 0L;
+
+        this.status = PaymentStatus.REFUNDED;
+        return paymentPrice;
+    }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/domain/Payment.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/Payment.java
@@ -1,0 +1,31 @@
+package com.project.bookstudy.enrollment.domain;
+
+import com.project.bookstudy.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "payment_id")
+    private Long id;
+
+    private LocalDateTime paymentDt;
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus status;
+    private Long price;
+    private Long discountPrice;
+    private Long paymentPrice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/project/bookstudy/enrollment/domain/PaymentStatus.java
+++ b/src/main/java/com/project/bookstudy/enrollment/domain/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.project.bookstudy.enrollment.domain;
+
+public enum PaymentStatus {
+    SUCCESS, REFUNDED
+}

--- a/src/main/java/com/project/bookstudy/enrollment/dto/CreateEnrollmentResponse.java
+++ b/src/main/java/com/project/bookstudy/enrollment/dto/CreateEnrollmentResponse.java
@@ -1,0 +1,15 @@
+package com.project.bookstudy.enrollment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateEnrollmentResponse {
+    private Long enrollmentId;
+}

--- a/src/main/java/com/project/bookstudy/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/project/bookstudy/enrollment/repository/EnrollmentRepository.java
@@ -1,0 +1,7 @@
+package com.project.bookstudy.enrollment.repository;
+
+import com.project.bookstudy.enrollment.domain.Enrollment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+}

--- a/src/main/java/com/project/bookstudy/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/project/bookstudy/enrollment/repository/EnrollmentRepository.java
@@ -1,7 +1,8 @@
 package com.project.bookstudy.enrollment.repository;
 
 import com.project.bookstudy.enrollment.domain.Enrollment;
+import com.project.bookstudy.study_group.repository.CustomEnrollmentRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long>, CustomEnrollmentRepository {
 }

--- a/src/main/java/com/project/bookstudy/enrollment/repository/PaymentRepository.java
+++ b/src/main/java/com/project/bookstudy/enrollment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.project.bookstudy.enrollment.repository;
+
+import com.project.bookstudy.enrollment.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
@@ -11,6 +11,8 @@ import com.project.bookstudy.study_group.domain.StudyGroup;
 import com.project.bookstudy.study_group.dto.EnrollmentDto;
 import com.project.bookstudy.study_group.repository.StudyGroupRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -102,5 +104,12 @@ public class EnrollmentService {
                 throw new IllegalStateException(ErrorCode.DUPLICATE_ENROLLMENT_ERROR.getDescription());
             }
         }
+    }
+
+    public Page<EnrollmentDto> getEnrollmentList(Pageable pageable, Long memberId) {
+        Page<Enrollment> enrollments = enrollmentRepository.searchEnrollment(pageable, memberId);
+        Page<EnrollmentDto> enrollmentDtoList = enrollments
+                .map(content -> EnrollmentDto.fromEntity(content));
+        return enrollmentDtoList;
     }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
@@ -25,7 +25,7 @@ public class EnrollmentService {
 
     @Transactional
     @DistributedLock(key = "#studyGroupId")
-    public void enroll(Long studyGroupId, Authentication authentication) {
+    public Long enroll(Long studyGroupId, Authentication authentication) {
         //Collection Fetch Join → Batch Size 적용 고려
         StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
                 .orElseThrow(() -> new IllegalArgumentException(ErrorCode.STUDY_GROUP_NOT_FOUND.getDescription()));
@@ -54,6 +54,7 @@ public class EnrollmentService {
         Enrollment enrollment = Enrollment.createEnrollment(member, studyGroup);
         enrollmentRepository.save(enrollment);
 
+        return enrollment.getId();
     }
 
     // 중복 검사

--- a/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
@@ -24,10 +24,10 @@ public class EnrollmentService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    @DistributedLock(key = "#request.studyGroupId")
-    public void enroll(Long StudyGroupId, Authentication authentication) {
+    @DistributedLock(key = "#studyGroupId")
+    public void enroll(Long studyGroupId, Authentication authentication) {
         //Collection Fetch Join → Batch Size 적용 고려
-        StudyGroup studyGroup = studyGroupRepository.findById(StudyGroupId)
+        StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
                 .orElseThrow(() -> new IllegalArgumentException(ErrorCode.STUDY_GROUP_NOT_FOUND.getDescription()));
 
         Member member = memberRepository.findByEmail(authentication.getName())

--- a/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
@@ -1,0 +1,13 @@
+package com.project.bookstudy.enrollment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EnrollmentService {
+
+
+}

--- a/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
@@ -1,6 +1,16 @@
 package com.project.bookstudy.enrollment.service;
 
+import com.project.bookstudy.common.aop.DistributedLock;
+import com.project.bookstudy.common.dto.ErrorCode;
+import com.project.bookstudy.common.exception.MemberException;
+import com.project.bookstudy.enrollment.domain.Enrollment;
+import com.project.bookstudy.enrollment.repository.EnrollmentRepository;
+import com.project.bookstudy.member.domain.Member;
+import com.project.bookstudy.member.repository.MemberRepository;
+import com.project.bookstudy.study_group.domain.StudyGroup;
+import com.project.bookstudy.study_group.repository.StudyGroupRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,5 +19,57 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class EnrollmentService {
 
+    private final EnrollmentRepository enrollmentRepository;
+    private final StudyGroupRepository studyGroupRepository;
+    private final MemberRepository memberRepository;
 
+    @Transactional
+    @DistributedLock(key = "#request.studyGroupId")
+    public void enroll(Long StudyGroupId, Authentication authentication) {
+        //Collection Fetch Join → Batch Size 적용 고려
+        StudyGroup studyGroup = studyGroupRepository.findById(StudyGroupId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.STUDY_GROUP_NOT_FOUND.getDescription()));
+
+        Member member = memberRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getDescription()));
+
+        // 본인이 만든 스터디그룹인 경우 신청 불가
+        if (studyGroup.getLeader().getId() == member.getId()) {
+            throw new MemberException(ErrorCode.LEADER_ENROLLMENT_ERROR);
+        }
+
+        // 모집 기간 조회
+        if (!studyGroup.isRecruitmentStarted()) {
+            throw new IllegalStateException(ErrorCode.RECRUITMENT_DATE_END.getDescription());
+        }
+
+        // 중복 신청 검사
+        validate(member, studyGroup);
+
+        // 현재 신청 인원 체크
+        if (!studyGroup.isApplicable()) {
+            throw new IllegalStateException(ErrorCode.STUDY_GROUP_FULL.getDescription());
+        }
+
+        Enrollment enrollment = Enrollment.createEnrollment(member, studyGroup);
+        enrollmentRepository.save(enrollment);
+
+    }
+
+    // 중복 검사
+    public void validate(Member member, StudyGroup studyGroup) {
+        if (studyGroup.getLeader().getId() == member.getId()) {
+            throw new IllegalStateException(ErrorCode.LEADER_ENROLLMENT_ERROR.getDescription());
+        }
+
+        validateDuplicateApplication(member, studyGroup);
+    }
+
+    private void validateDuplicateApplication(Member member, StudyGroup studyGroup) {
+        for (Enrollment enrollment : studyGroup.getEnrollments()) {
+            if (enrollment.getMember() == member) {
+                throw new IllegalStateException(ErrorCode.DUPLICATE_ENROLLMENT_ERROR.getDescription());
+            }
+        }
+    }
 }

--- a/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
@@ -8,6 +8,7 @@ import com.project.bookstudy.enrollment.repository.EnrollmentRepository;
 import com.project.bookstudy.member.domain.Member;
 import com.project.bookstudy.member.repository.MemberRepository;
 import com.project.bookstudy.study_group.domain.StudyGroup;
+import com.project.bookstudy.study_group.dto.EnrollmentDto;
 import com.project.bookstudy.study_group.repository.StudyGroupRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -76,6 +77,14 @@ public class EnrollmentService {
         }
 
         enrollment.cancel();
+    }
+
+    public EnrollmentDto getEnrollment(Long enrollmentId) {
+        Enrollment enrollment = enrollmentRepository.findByIdWithAll(enrollmentId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.ENROLLMENT_NOT_FOUND.getDescription()));
+
+        //스터디 정보(StudyDto), 신청일(Payment 에 있음), PaymentDto 이렇게 내려 준다.
+        return EnrollmentDto.fromEntity(enrollment);
     }
 
     // 중복 검사

--- a/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
@@ -89,6 +89,13 @@ public class EnrollmentService {
         return EnrollmentDto.fromEntity(enrollment);
     }
 
+    public Page<EnrollmentDto> getEnrollmentList(Pageable pageable, Long memberId) {
+        Page<Enrollment> enrollments = enrollmentRepository.searchEnrollment(pageable, memberId);
+        Page<EnrollmentDto> enrollmentDtoList = enrollments
+                .map(content -> EnrollmentDto.fromEntity(content));
+        return enrollmentDtoList;
+    }
+
     // 중복 검사
     public void validate(Member member, StudyGroup studyGroup) {
         if (studyGroup.getLeader().getId() == member.getId()) {
@@ -106,10 +113,5 @@ public class EnrollmentService {
         }
     }
 
-    public Page<EnrollmentDto> getEnrollmentList(Pageable pageable, Long memberId) {
-        Page<Enrollment> enrollments = enrollmentRepository.searchEnrollment(pageable, memberId);
-        Page<EnrollmentDto> enrollmentDtoList = enrollments
-                .map(content -> EnrollmentDto.fromEntity(content));
-        return enrollmentDtoList;
-    }
+
 }

--- a/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
@@ -66,6 +66,15 @@ public class EnrollmentService {
         if (enrollment.getStudyGroup().isStarted()) {
             throw new IllegalStateException(ErrorCode.STUDY_GROUP_CANCEL_FAIL.getDescription());
         }
+
+        Member member = memberRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getDescription()));
+
+        // 본인이 신청한 내역이 아니면 신청 취소 불가
+        if (enrollment.getMember().getId() != member.getId()) {
+            throw new MemberException(ErrorCode.ENROLLMENT_CANCEL_FAIL);
+        }
+
         enrollment.cancel();
     }
 

--- a/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/project/bookstudy/enrollment/service/EnrollmentService.java
@@ -57,6 +57,18 @@ public class EnrollmentService {
         return enrollment.getId();
     }
 
+    @Transactional
+    public void cancel(Long enrollmentId, Authentication authentication) {
+
+        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.ENROLLMENT_NOT_FOUND.getDescription()));
+
+        if (enrollment.getStudyGroup().isStarted()) {
+            throw new IllegalStateException(ErrorCode.STUDY_GROUP_CANCEL_FAIL.getDescription());
+        }
+        enrollment.cancel();
+    }
+
     // 중복 검사
     public void validate(Member member, StudyGroup studyGroup) {
         if (studyGroup.getLeader().getId() == member.getId()) {

--- a/src/main/java/com/project/bookstudy/member/domain/Member.java
+++ b/src/main/java/com/project/bookstudy/member/domain/Member.java
@@ -56,4 +56,8 @@ public class Member {
         this.point -= point;
     }
 
+    public void chargePoint(Long point) {
+        this.point += point;
+    }
+
 }

--- a/src/main/java/com/project/bookstudy/member/domain/Member.java
+++ b/src/main/java/com/project/bookstudy/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.project.bookstudy.member.domain;
 
+import com.project.bookstudy.common.dto.ErrorCode;
 import lombok.*;
 
 import javax.persistence.*;
@@ -48,6 +49,11 @@ public class Member {
 
     public void updateRefreshToken(String updateRefreshToken) {
         this.refreshToken = updateRefreshToken;
+    }
+
+    public void usePoint(Long point) {
+        if (this.point < point) throw new IllegalStateException(ErrorCode.POINT_NOT_ENOUGH.getDescription());
+        this.point -= point;
     }
 
 }

--- a/src/main/java/com/project/bookstudy/study_group/domain/StudyGroup.java
+++ b/src/main/java/com/project/bookstudy/study_group/domain/StudyGroup.java
@@ -1,6 +1,8 @@
 package com.project.bookstudy.study_group.domain;
 
 import com.project.bookstudy.common.dto.ErrorCode;
+import com.project.bookstudy.enrollment.domain.Enrollment;
+import com.project.bookstudy.enrollment.domain.EnrollmentStatus;
 import com.project.bookstudy.member.domain.Member;
 import com.project.bookstudy.study_group.domain.param.CreateStudyGroupParam;
 import com.project.bookstudy.study_group.domain.param.UpdateStudyGroupParam;
@@ -8,6 +10,7 @@ import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +43,12 @@ public class StudyGroup {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "leader_id")
     private Member leader;
+
+    // 동시성 이슈 해결
+    @OneToMany(mappedBy = "studyGroup", cascade = CascadeType.ALL)
+    private List<Enrollment> enrollments = new ArrayList<>();
+
+    LocalDate nowDate = LocalDate.now();
 
     @Builder
     public StudyGroup(String subject, String contents, String contentsDetail, int maxSize, Long price, LocalDateTime studyStartDt, LocalDateTime studyEndDt
@@ -104,6 +113,28 @@ public class StudyGroup {
         }
 
         status = StudyGroupStatus.RECRUIT_CANCEL;
+    }
+
+    /**
+     * 모집 진행 기간인지 확인
+     */
+    public boolean isRecruitmentStarted() {
+        if (getRecruitmentStartDt().toLocalDate().minusDays(1).isBefore(nowDate)
+                && nowDate.isBefore(getRecruitmentEndDt().toLocalDate().plusDays(1))) {
+            return true;
+        } return false;
+    }
+
+    public boolean isApplicable() {
+
+        long count = enrollments.stream()
+                .filter((i) -> i.getEnrollmentStatus() == EnrollmentStatus.RESERVED)
+                .count();
+
+        if ( count < maxSize) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/project/bookstudy/study_group/domain/StudyGroup.java
+++ b/src/main/java/com/project/bookstudy/study_group/domain/StudyGroup.java
@@ -128,7 +128,7 @@ public class StudyGroup {
     public boolean isApplicable() {
 
         long count = enrollments.stream()
-                .filter((i) -> i.getEnrollmentStatus() == EnrollmentStatus.RESERVED)
+                .filter((i) -> i.getStatus() == EnrollmentStatus.RESERVED)
                 .count();
 
         if ( count < maxSize) {

--- a/src/main/java/com/project/bookstudy/study_group/dto/EnrollmentDto.java
+++ b/src/main/java/com/project/bookstudy/study_group/dto/EnrollmentDto.java
@@ -1,0 +1,37 @@
+package com.project.bookstudy.study_group.dto;
+
+import com.project.bookstudy.enrollment.domain.Enrollment;
+import com.project.bookstudy.enrollment.domain.EnrollmentStatus;
+import com.project.bookstudy.enrollment.domain.Payment;
+import com.project.bookstudy.study_group.domain.StudyGroup;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class EnrollmentDto {
+
+    private Long id;
+    private EnrollmentStatus status;
+    private StudyGroupDto studyGroup;
+    private PaymentDto payment;
+
+    @Builder
+    private EnrollmentDto(Long id, EnrollmentStatus status, StudyGroupDto studyGroup, PaymentDto payment) {
+        this.id = id;
+        this.status = status;
+        this.studyGroup = studyGroup;
+        this.payment = payment;
+    }
+
+    public static EnrollmentDto fromEntity(Enrollment enrollment) {
+        StudyGroup studyGroup = enrollment.getStudyGroup();
+        Payment payment = enrollment.getPayment();
+
+        return EnrollmentDto.builder()
+                .id(enrollment.getId())
+                .status(enrollment.getStatus())
+                .studyGroup(StudyGroupDto.fromEntity(studyGroup))
+                .payment(PaymentDto.fromEntity(payment))
+                .build();
+    }
+}

--- a/src/main/java/com/project/bookstudy/study_group/dto/PaymentDto.java
+++ b/src/main/java/com/project/bookstudy/study_group/dto/PaymentDto.java
@@ -1,0 +1,44 @@
+package com.project.bookstudy.study_group.dto;
+
+import com.project.bookstudy.enrollment.domain.Payment;
+import com.project.bookstudy.enrollment.domain.PaymentStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PaymentDto {
+
+    private Long id;
+
+    private LocalDateTime paymentDate;
+    private PaymentStatus status;
+
+    private Long price;
+    private Long discountPrice;
+    private Long paymentPrice;
+
+    @Builder
+    private PaymentDto(Long id, LocalDateTime paymentDate, PaymentStatus status, Long price, Long discountPrice, Long paymentPrice) {
+
+        this.id = id;
+        this.paymentDate = paymentDate;
+        this.status = status;
+        this.price = price;
+        this.discountPrice = discountPrice;
+        this.paymentPrice = paymentPrice;
+    }
+
+    public static PaymentDto fromEntity(Payment payment) {
+
+        return PaymentDto.builder()
+                .id(payment.getId())
+                .paymentDate(payment.getPaymentDt())
+                .status(payment.getStatus())
+                .price(payment.getPrice())
+                .discountPrice(payment.getDiscountPrice())
+                .paymentPrice(payment.getPaymentPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/project/bookstudy/study_group/dto/request/EnrollmentSearchCond.java
+++ b/src/main/java/com/project/bookstudy/study_group/dto/request/EnrollmentSearchCond.java
@@ -1,0 +1,9 @@
+package com.project.bookstudy.study_group.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class EnrollmentSearchCond {
+
+    private Long memberId;
+}

--- a/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepository.java
+++ b/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepository.java
@@ -1,9 +1,13 @@
 package com.project.bookstudy.study_group.repository;
 
 import com.project.bookstudy.enrollment.domain.Enrollment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface CustomEnrollmentRepository {
     public Optional<Enrollment> findByIdWithAll(Long id);
+
+    public Page<Enrollment> searchEnrollment(Pageable pageable, Long memberId);
 }

--- a/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepository.java
+++ b/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepository.java
@@ -1,0 +1,9 @@
+package com.project.bookstudy.study_group.repository;
+
+import com.project.bookstudy.enrollment.domain.Enrollment;
+
+import java.util.Optional;
+
+public interface CustomEnrollmentRepository {
+    public Optional<Enrollment> findByIdWithAll(Long id);
+}

--- a/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepositoryImpl.java
+++ b/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepositoryImpl.java
@@ -4,7 +4,11 @@ import com.project.bookstudy.enrollment.domain.Enrollment;
 import com.project.bookstudy.member.domain.QMember;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.project.bookstudy.enrollment.domain.QEnrollment.enrollment;
@@ -30,5 +34,28 @@ public class CustomEnrollmentRepositoryImpl implements CustomEnrollmentRepositor
                 .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Page<Enrollment> searchEnrollment(Pageable pageable, Long memberId) {
+
+        QMember leader = new QMember("m");
+
+        List<Enrollment> enrollmentList = jpaQueryFactory.selectFrom(enrollment)
+                .join(enrollment.studyGroup, studyGroup).fetchJoin()
+                .join(studyGroup.leader, leader).fetchJoin()
+                .join(enrollment.payment, payment).fetchJoin()
+                .join(enrollment.member, member).fetchJoin()
+                .where(member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory.select(enrollment.count())
+                .from(enrollment)
+                .where(enrollment.member.id.eq(memberId))
+                .fetchOne();
+
+        return new PageImpl<>(enrollmentList, pageable, total);
     }
 }

--- a/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepositoryImpl.java
+++ b/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepositoryImpl.java
@@ -41,21 +41,40 @@ public class CustomEnrollmentRepositoryImpl implements CustomEnrollmentRepositor
 
         QMember leader = new QMember("m");
 
-        List<Enrollment> enrollmentList = jpaQueryFactory.selectFrom(enrollment)
-                .join(enrollment.studyGroup, studyGroup).fetchJoin()
-                .join(studyGroup.leader, leader).fetchJoin()
-                .join(enrollment.payment, payment).fetchJoin()
-                .join(enrollment.member, member).fetchJoin()
-                .where(member.id.eq(memberId))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+        if (memberId != null) {
+            List<Enrollment> enrollmentList = jpaQueryFactory.selectFrom(enrollment)
+                    .join(enrollment.studyGroup, studyGroup).fetchJoin()
+                    .join(studyGroup.leader, leader).fetchJoin()
+                    .join(enrollment.payment, payment).fetchJoin()
+                    .join(enrollment.member, member).fetchJoin()
+                    .where(member.id.eq(memberId))
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize())
+                    .fetch();
 
-        Long total = jpaQueryFactory.select(enrollment.count())
-                .from(enrollment)
-                .where(enrollment.member.id.eq(memberId))
-                .fetchOne();
+            Long total = jpaQueryFactory.select(enrollment.count())
+                    .from(enrollment)
+                    .where(enrollment.member.id.eq(memberId))
+                    .fetchOne();
 
-        return new PageImpl<>(enrollmentList, pageable, total);
+            return new PageImpl<>(enrollmentList, pageable, total);
+        } else {
+            List<Enrollment> enrollmentList = jpaQueryFactory.selectFrom(enrollment)
+                    .join(enrollment.studyGroup, studyGroup).fetchJoin()
+                    .join(studyGroup.leader, leader).fetchJoin()
+                    .join(enrollment.payment, payment).fetchJoin()
+                    .join(enrollment.member, member).fetchJoin()
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize())
+                    .fetch();
+
+            Long total = jpaQueryFactory.select(enrollment.count())
+                    .from(enrollment)
+                    .fetchOne();
+
+            return new PageImpl<>(enrollmentList, pageable, total);
+        }
+
+
     }
 }

--- a/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepositoryImpl.java
+++ b/src/main/java/com/project/bookstudy/study_group/repository/CustomEnrollmentRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.project.bookstudy.study_group.repository;
+
+import com.project.bookstudy.enrollment.domain.Enrollment;
+import com.project.bookstudy.member.domain.QMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.project.bookstudy.enrollment.domain.QEnrollment.enrollment;
+import static com.project.bookstudy.enrollment.domain.QPayment.payment;
+import static com.project.bookstudy.member.domain.QMember.member;
+import static com.project.bookstudy.study_group.domain.QStudyGroup.studyGroup;
+
+@RequiredArgsConstructor
+public class CustomEnrollmentRepositoryImpl implements CustomEnrollmentRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<Enrollment> findByIdWithAll(Long id) {
+
+        QMember leader = new QMember("m");
+
+        Enrollment result = jpaQueryFactory.selectFrom(enrollment)
+                .join(enrollment.studyGroup, studyGroup).fetchJoin()
+                .join(studyGroup.leader, leader).fetchJoin()
+                .join(enrollment.payment, payment).fetchJoin()
+                .join(enrollment.member, member).fetchJoin()
+                .where(enrollment.id.eq(id))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/project/bookstudy/study_group/repository/StudyGroupRepository.java
+++ b/src/main/java/com/project/bookstudy/study_group/repository/StudyGroupRepository.java
@@ -2,6 +2,13 @@ package com.project.bookstudy.study_group.repository;
 
 import com.project.bookstudy.study_group.domain.StudyGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long>, CustomStudyGroupRepository {
+
+    @Query("select s from StudyGroup s left join fetch s.enrollments where s.id = :id")
+    Optional<StudyGroup> findByIdFetchEnrollment(@Param("id") Long id);
 }

--- a/src/test/java/com/project/bookstudy/enrollment/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/project/bookstudy/enrollment/service/EnrollmentServiceTest.java
@@ -1,0 +1,155 @@
+package com.project.bookstudy.enrollment.service;
+
+import com.project.bookstudy.common.dto.ErrorCode;
+import com.project.bookstudy.common.exception.MemberException;
+import com.project.bookstudy.enrollment.domain.Enrollment;
+import com.project.bookstudy.enrollment.domain.EnrollmentStatus;
+import com.project.bookstudy.enrollment.repository.EnrollmentRepository;
+import com.project.bookstudy.enrollment.repository.PaymentRepository;
+import com.project.bookstudy.member.domain.Member;
+import com.project.bookstudy.member.repository.MemberRepository;
+import com.project.bookstudy.study_group.domain.StudyGroup;
+import com.project.bookstudy.study_group.dto.StudyGroupDto;
+import com.project.bookstudy.study_group.dto.request.CreateStudyGroupRequest;
+import com.project.bookstudy.study_group.repository.StudyGroupRepository;
+import com.project.bookstudy.study_group.service.StudyGroupService;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.SoftAssertions;
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.annotation.Rollback;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+@Rollback
+public class EnrollmentServiceTest {
+
+    @Autowired
+    EntityManager entityManager;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    StudyGroupRepository studyGroupRepository;
+    @Autowired
+    EnrollmentRepository enrollmentRepository;
+    @Autowired
+    EnrollmentService enrollmentService;
+    @Autowired
+    StudyGroupService studyGroupService;
+    @Autowired
+    PaymentRepository paymentRepository;
+
+
+    @AfterEach
+    void tearDown() {
+        enrollmentRepository.deleteAllInBatch();
+        paymentRepository.deleteAllInBatch();
+        studyGroupRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("스터디 그룹 신청 성공")
+    @Test
+    void enrollSuccess() {
+
+        //given
+        Long memberPoint = 50_000L;
+
+        Member leader = createMember("스터디 리더", "leader@naver.com");
+        Member member = createMember("스터디 멤버", "member@naver.com");
+
+        member.chargePoint(memberPoint);
+        Authentication authentication1 = createAuthenticationLeader();
+        Authentication authentication2 = createAuthenticationMember();
+
+        memberRepository.saveAll(List.of(leader, member));
+
+        CreateStudyGroupRequest request = createStudyCreateGroupRequest(leader.getId(),
+                LocalDateTime.of(2023, 12, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 12, 2, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 30, 0, 0, 0), "subject", "contents");
+        StudyGroupDto response = studyGroupService.createStudyGroup(authentication1, request.toStudyGroupParam());
+        StudyGroup studyGroup = studyGroupRepository.findById(response.getId())
+                .orElseThrow(() -> new IllegalArgumentException("스터디 없음"));
+
+        //when
+        Long enrollmentId = enrollmentService.enroll(studyGroup.getId(), authentication2);
+        //then
+        Enrollment findEnrollment = enrollmentRepository.findById(enrollmentId).orElseThrow();
+
+        assertThat(findEnrollment.getId()).isEqualTo(enrollmentId);
+
+    }
+
+    /**
+     * @param name
+     * @param email 회원가입 메서드
+     */
+    private Member createMember(String name, String email) {
+        return Member.builder()
+                .name(name)
+                .career("career")
+                .phone("phone")
+                .email(email)
+                .build();
+    }
+
+    /**
+     * @param memberId
+     * @param studyStartDt
+     * @param studyEndDt
+     * @param recruitmentStartDt
+     * @param recruitmentEndDt
+     * @param subject
+     * @param contents           회원가입 request 값
+     */
+    private CreateStudyGroupRequest createStudyCreateGroupRequest(Long memberId, LocalDateTime studyStartDt, LocalDateTime studyEndDt, LocalDateTime recruitmentStartDt, LocalDateTime recruitmentEndDt, String subject, String contents) {
+        return CreateStudyGroupRequest.builder()
+                .memberId(memberId)
+                .subject(subject)
+                .contents(contents)
+                .contentsDetail("contentsDetail")
+                .maxSize(10)
+                .price(10000L)
+                .studyStartDt(studyStartDt)
+                .studyEndDt(studyEndDt)
+                .recruitmentStartDt(recruitmentStartDt)
+                .recruitmentEndDt(recruitmentEndDt)
+                .build();
+    }
+
+    /**
+     * 토큰 인증을 위한 인증 기능 메서드
+     */
+    private Authentication createAuthenticationLeader() {
+
+        String email = "leader@naver.com";
+        String password = "leader123";
+
+        return new UsernamePasswordAuthenticationToken(email, password,
+                AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+
+    private Authentication createAuthenticationMember() {
+
+        String email = "member@naver.com";
+        String password = "member123";
+
+        return new UsernamePasswordAuthenticationToken(email, password,
+                AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/src/test/java/com/project/bookstudy/enrollment/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/project/bookstudy/enrollment/service/EnrollmentServiceTest.java
@@ -168,6 +168,41 @@ public class EnrollmentServiceTest {
         assertThat(enrollmentDto.getStudyGroup().getId()).isEqualTo(enrollment.getStudyGroup().getId());
     }
 
+    @Test
+    @DisplayName("스터디 그룹 단일조회 실패 - 신청 id 존재하지 않는 경우")
+    @Transactional
+    void getEnrollmentFailed() {
+        //given
+        Member member1 = createMember("member","member@naver.com");
+        memberRepository.save(member1);
+
+        Member leader1 = createMember("leader", "leader@naver.com");
+        memberRepository.save(leader1);
+
+        Authentication authentication1 = createAuthenticationLeader();
+        Authentication authentication2 = createAuthenticationMember();
+
+        Long originMemberPoint = 1000000L;
+        member1.chargePoint(originMemberPoint);
+
+        CreateStudyGroupRequest request = createStudyCreateGroupRequest(leader1.getId(),
+                LocalDateTime.of(2023, 12, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 12, 2, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 30, 0, 0, 0), "subject", "contents");
+        StudyGroupDto response = studyGroupService.createStudyGroup(authentication1, request.toStudyGroupParam());
+        StudyGroup studyGroup = studyGroupRepository.findById(response.getId())
+                .orElseThrow(() -> new IllegalArgumentException("스터디 없음"));
+
+
+        Long enrollmentId = enrollmentService.enroll(studyGroup.getId(), authentication2);
+
+        //when
+        //then
+        assertThat(enrollmentRepository.findById(enrollmentId + 1)).isEmpty();
+
+    }
+
 
 
     /**

--- a/src/test/java/com/project/bookstudy/enrollment/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/project/bookstudy/enrollment/service/EnrollmentServiceTest.java
@@ -27,7 +27,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -203,6 +205,58 @@ public class EnrollmentServiceTest {
 
     }
 
+    @Test
+    @DisplayName("스터디 그룹 전체조회 성공")
+    @Transactional
+    void getEnrollmentListSuccess() {
+        //given
+        Member member1 = createMember("member","member@naver.com");
+        memberRepository.save(member1);
+
+        Member leader1 = createMember("leader", "leader@naver.com");
+        memberRepository.save(leader1);
+
+        Authentication authentication1 = createAuthenticationLeader();
+        Authentication authentication2 = createAuthenticationMember();
+
+        Long originMemberPoint = 1000000L;
+        member1.chargePoint(originMemberPoint);
+
+        CreateStudyGroupRequest request1 = createStudyCreateGroupRequest(leader1.getId(),
+                LocalDateTime.of(2023, 12, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 12, 2, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 30, 0, 0, 0), "subject", "contents");
+        StudyGroupDto response1 = studyGroupService.createStudyGroup(authentication1, request1.toStudyGroupParam());
+
+        CreateStudyGroupRequest request2 = createStudyCreateGroupRequest(leader1.getId(),
+                LocalDateTime.of(2023, 12, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 12, 2, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 30, 0, 0, 0), "subject", "contents");
+        StudyGroupDto response2 = studyGroupService.createStudyGroup(authentication1, request1.toStudyGroupParam());
+
+        StudyGroup studyGroup1 = studyGroupRepository.findById(response1.getId())
+                .orElseThrow(() -> new IllegalArgumentException("스터디 없음"));
+        StudyGroup studyGroup2 = studyGroupRepository.findById(response2.getId())
+                .orElseThrow(() -> new IllegalArgumentException("스터디 없음"));
+
+
+        Long enrollmentId1 = enrollmentService.enroll(studyGroup1.getId(), authentication2);
+        Long enrollmentId2 = enrollmentService.enroll(studyGroup2.getId(), authentication2);
+
+        Optional<Enrollment> enrollment1 = enrollmentRepository.findById(enrollmentId1);
+        Optional<Enrollment> enrollment2 = enrollmentRepository.findById(enrollmentId2);
+
+        List<Optional<Enrollment>> enrollmentList = new ArrayList<>();
+        enrollmentList.add(enrollment1);
+        enrollmentList.add(enrollment2);
+
+
+        //then
+        assertThat(enrollmentList.size()).isEqualTo(2);
+
+    }
 
 
     /**


### PR DESCRIPTION
##  Feature


- 스터디그룹 신청 기능 구현했습니다.
  - 신청 시 동시성 이슈를 해결하기 위해 Lock을 적용했습니다.
- 스터디그룹 신청 조회 기능 (단일, 전체) 구현했습니다.
  - 페이징처리 했습니다.
- 스터디그룹 신청 취소 기능 구현했습니다.

## Test

- [x] API 테스트
- [x] 테스트 코드

- API 테스트

1. 스터디그룹 신청 - 신청 컬럼 id 반환
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/c7d6c2f6-2c9e-4b43-aad1-310f6c2d30d6)


2. 스터디그룹 신청 취소 전
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/9d64580a-0cc5-4c8a-ba91-a64f9e3e8309)

3. 스터디그룹 신청 취소 후
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/20d1fa48-fdc3-44cc-ad7d-5a4e3317a20d)

4. 스터디그룹 신청내역 단일조회 (7번 조회)
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/7b5e4df1-e524-490c-8565-a194b3211fc9)
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/d671dd2d-92c4-4388-9f72-243d4062e0db)

5. 스터디그룹 신청내역 전체조회
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/9efa1656-7dfb-4abf-a28c-b89309c9da9a)

6. 스터디그룹 신청내역 전체조회 (특정 회원 기준 전체 신청 내역조회)
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/a040980f-3ea1-41b8-9002-d685b84e21e8)


- 테스트 코드
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/4a805885-a557-47f4-a8de-cee1342dc20a)

