### PR TITLE
댓글 API - DELETE 기능

### DIFF
--- a/src/main/java/com/project/bookstudy/comment/controller/CommentController.java
+++ b/src/main/java/com/project/bookstudy/comment/controller/CommentController.java
@@ -49,9 +49,26 @@ public class CommentController {
         return ResponseEntity.ok(commentService.getRootOrChildCommentList(parentId, pageable));
     }
 
+    /**
+     *
+     * @param commentId
+     * @param request
+     * 댓글 수정
+     */
     @PatchMapping("/{id}")
     public ResponseEntity<Void> updateComment(@PathVariable("id") Long commentId, @RequestBody UpdateCommentRequest request) {
         commentService.updateComment(commentId, request.getUpdateCommentParam());
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     *
+     * @param commentId
+     * 댓글 삭제
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteComment(@PathVariable("id") Long commentId) {
+        commentService.deleteComment(commentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/project/bookstudy/comment/repository/CustomCommentRepository.java
+++ b/src/main/java/com/project/bookstudy/comment/repository/CustomCommentRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface CustomCommentRepository {
     Page<Comment> findRootOrChildByParentId(Long id, Pageable pageable);
 
+    List<Comment> findRootOrChildByParentIdInDelete(Long id);
+
 }

--- a/src/main/java/com/project/bookstudy/comment/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/project/bookstudy/comment/repository/CustomCommentRepositoryImpl.java
@@ -29,6 +29,16 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository{
         return new PageImpl<>(queryResults.getResults(), pageable, queryResults.getTotal());
     }
 
+    @Override
+    public List<Comment> findRootOrChildByParentIdInDelete(Long id) {
+
+        List<Comment> childCommentList = jpaQueryFactory.selectFrom(comment)
+                .where(getRootOrChild(id))
+                .fetch();
+
+        return childCommentList;
+    }
+
     private BooleanExpression getRootOrChild(Long id) {
         return id != null ? comment.parent.id.eq(id) : null;
     }

--- a/src/main/java/com/project/bookstudy/comment/service/CommentService.java
+++ b/src/main/java/com/project/bookstudy/comment/service/CommentService.java
@@ -76,4 +76,27 @@ public class CommentService {
         comment.update(updateParam);
     }
 
+    @Transactional
+    public void deleteComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.COMMENT_NOT_FOUND.getDescription()));
+        if (comment.getIsDeleted()) {
+            throw new IllegalArgumentException(ErrorCode.COMMENT_ALREADY_DELETED.getDescription());
+        }
+        //comment.delete();
+        deleteChildCommentAndParentComment(comment);
+    }
+
+    private void deleteChildCommentAndParentComment(Comment comment) {
+
+        if (comment == null) {
+            return;
+        }
+        List<Comment> childComments = commentRepository.findRootOrChildByParentIdInDelete(comment.getId());
+        for (Comment childComment : childComments) {
+            deleteChildCommentAndParentComment(childComment);
+        }
+
+        commentRepository.delete(comment);
+    }
 }

--- a/src/main/java/com/project/bookstudy/common/dto/ErrorCode.java
+++ b/src/main/java/com/project/bookstudy/common/dto/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND("해당 댓글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     CATEGORY_NOT_FOUND("해당 카테고리가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     COMMENT_DELETE_FAIL("댓글 삭제를 실패했습니다.", HttpStatus.BAD_REQUEST),
+    COMMENT_ALREADY_DELETED("이미 삭제된 댓글입니다.", HttpStatus.BAD_REQUEST),
     STUDY_GROUP_FULL("스터디 그룹 인원이 다 찼습니다.", HttpStatus.BAD_REQUEST),
     STUDY_GROUP_CANCEL_FAIL("스터디 그룹 삭제 실패", HttpStatus.BAD_REQUEST),
     POINT_NOT_ENOUGH("포인트가 부족합니다.", HttpStatus.BAD_REQUEST),

--- a/src/test/java/com/project/bookstudy/service/CommentServiceTest.java
+++ b/src/test/java/com/project/bookstudy/service/CommentServiceTest.java
@@ -362,6 +362,63 @@ public class CommentServiceTest {
                 .hasMessageContaining(ErrorCode.COMMENT_NOT_FOUND.getDescription());
     }
 
+    @Test
+    @Transactional
+    @DisplayName("댓글 삭제 성공 - 부모 댓글 삭제 시, 자식 댓글도 같이 삭제")
+    void deletePostSuccess() throws IOException {
+        //given
+        Member member = createMember("member", "member@naver.com");
+        memberRepository.save(member);
+        Member leader = createMember("leader", "leader@naver.com");
+        memberRepository.save(leader);
+
+        Authentication authentication = createAuthenticationMember();
+
+        CreateStudyGroupRequest request = createStudyCreateGroupRequest(leader.getId(),
+                LocalDateTime.of(2023, 12, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 12, 2, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 30, 0, 0, 0), "subject", "contents");
+        StudyGroupDto response1 = studyGroupService.createStudyGroup(authentication, request.toStudyGroupParam());
+        StudyGroup studyGroup = studyGroupRepository.findById(response1.getId())
+                .orElseThrow(() -> new IllegalArgumentException("스터디 없음"));
+        CreateCategoryRequest categoryRequest = makeCreateCategoryRequest(null, studyGroup);
+        Long categoryId = categoryService.createCategory(categoryRequest).getCategoryId();
+
+        CreatePostRequest postRequest = makeCreatePostRequest("게시글 만들기", "게시글 테스트", categoryId, studyGroup.getId());
+
+        List<MultipartFile> multipartFiles = new ArrayList<>();
+
+        multipartFiles.add(new MockMultipartFile("files", "file1.txt", "text/plain", "File 1 content".getBytes()));
+
+        CreatePostResponse createPost = postService.createPost(postRequest, multipartFiles, authentication);
+
+        Post findPost = postRepository.findById(createPost.getPostId())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.POST_NOT_FOUND.getDescription()));
+
+        CreateCommentRequest commentRequest = makeCreateCommentRequest(findPost.getId(), null, "댓글 작성");
+        CreateCommentResponse commentResponse = commentService.createComment(commentRequest, authentication);
+        Comment comment = commentRepository.findById(commentResponse.getCommentId())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.COMMENT_NOT_FOUND.getDescription()));
+        CreateCommentRequest commentRequest2 = makeCreateCommentRequest(findPost.getId(), comment.getId(), "댓글 작성");
+        CreateCommentResponse commentResponse2 = commentService.createComment(commentRequest2, authentication);
+
+        CreateCommentRequest commentRequest3 = makeCreateCommentRequest(findPost.getId(), comment.getId(), "댓글 작성");
+        CreateCommentResponse commentResponse3 = commentService.createComment(commentRequest3, authentication);
+
+        //when
+        commentService.deleteComment(comment.getId());
+        Comment deletedParentComment = commentRepository.findById(comment.getId()).orElse(null);
+        Comment deletedChildComment1 = commentRepository.findById(comment.getId()).orElse(null);
+        Comment deletedChildComment2 = commentRepository.findById(comment.getId()).orElse(null);
+
+        //then
+        assertThat(deletedParentComment).isNull();
+        assertThat(deletedChildComment1).isNull();
+        assertThat(deletedChildComment2).isNull();
+
+    }
+
     /**
      * @param name
      * @param email 회원가입 메서드

--- a/src/test/java/com/project/bookstudy/service/CommentServiceTest.java
+++ b/src/test/java/com/project/bookstudy/service/CommentServiceTest.java
@@ -419,6 +419,54 @@ public class CommentServiceTest {
 
     }
 
+    @Test
+    @Transactional
+    @DisplayName("댓글 삭제 실패 - 댓글 아이디가 조회되지 않는 경우")
+    void deletePostFailed() throws IOException {
+        //given
+        Member member = createMember("member", "member@naver.com");
+        memberRepository.save(member);
+        Member leader = createMember("leader", "leader@naver.com");
+        memberRepository.save(leader);
+
+        Authentication authentication = createAuthenticationMember();
+
+        CreateStudyGroupRequest request = createStudyCreateGroupRequest(leader.getId(),
+                LocalDateTime.of(2023, 12, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 12, 2, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 11, 30, 0, 0, 0), "subject", "contents");
+        StudyGroupDto response1 = studyGroupService.createStudyGroup(authentication, request.toStudyGroupParam());
+        StudyGroup studyGroup = studyGroupRepository.findById(response1.getId())
+                .orElseThrow(() -> new IllegalArgumentException("스터디 없음"));
+        CreateCategoryRequest categoryRequest = makeCreateCategoryRequest(null, studyGroup);
+        Long categoryId = categoryService.createCategory(categoryRequest).getCategoryId();
+
+        CreatePostRequest postRequest = makeCreatePostRequest("게시글 만들기", "게시글 테스트", categoryId, studyGroup.getId());
+
+        List<MultipartFile> multipartFiles = new ArrayList<>();
+
+        multipartFiles.add(new MockMultipartFile("files", "file1.txt", "text/plain", "File 1 content".getBytes()));
+
+        CreatePostResponse createPost = postService.createPost(postRequest, multipartFiles, authentication);
+
+        Post findPost = postRepository.findById(createPost.getPostId())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.POST_NOT_FOUND.getDescription()));
+
+        CreateCommentRequest commentRequest = makeCreateCommentRequest(findPost.getId(), null, "댓글 작성");
+        CreateCommentResponse commentResponse = commentService.createComment(commentRequest, authentication);
+        Comment comment = commentRepository.findById(commentResponse.getCommentId())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.COMMENT_NOT_FOUND.getDescription()));
+
+        //when
+        //then
+        assertThatThrownBy(() -> commentService.deleteComment(comment.getId() + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(ErrorCode.COMMENT_NOT_FOUND.getDescription());
+
+
+    }
+
     /**
      * @param name
      * @param email 회원가입 메서드


### PR DESCRIPTION
##  Feature

- 댓글 삭제 기능 구현했습니다.

## Test

- [x] API 테스트
- [x] 테스트 코드


## API 테스트
- 부모 댓글 아이디 : 6
- 자식 댓글 아이디 : 7, 8, 9

- 삭제 전
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/e1f66922-e655-49c4-b276-0d21e1593ab9)

- 삭제 후
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/88f2e48d-68cd-417e-9800-a6bd1cddfcd2)

## 테스트 코드
![image](https://github.com/ehdgus0221/online-book-studygroup/assets/66156319/a34525d1-1ec2-427b-bcdf-abd1de650f16)
